### PR TITLE
include level 1 headings in the table of contents by default

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,3 +22,7 @@ isHTML = true
 mediaType = "text/html"
 path = "_print"
 permalinkable = false
+
+[markup]
+  [markup.tableOfContents]
+    startLevel = 1


### PR DESCRIPTION
To fix https://projects.openanalytics.eu/issues/25234 globally